### PR TITLE
Add Node PluginInstance for js plugin

### DIFF
--- a/src-tauri/src/plugins/mod.rs
+++ b/src-tauri/src/plugins/mod.rs
@@ -140,9 +140,9 @@ pub async fn initialise_plugin(path: &path::PathBuf) -> anyhow::Result<()> {
 		devices.push(device.into());
 	}
 
-	let code_path = code_path.unwrap();
+	let code_path = code_path.unwrap().to_lowercase();
 
-	if code_path.ends_with(".html") {
+	if code_path.ends_with(".html") || code_path.ends_with(".htm") || code_path.ends_with(".xhtml") {
 		// Create a webview window for the plugin and call its registration function.
 		let url = "http://localhost:57118/".to_owned() + path.join(code_path).to_str().unwrap();
 		let window = tauri::WindowBuilder::new(APP_HANDLE.get().unwrap(), plugin_uuid.replace('.', "_"), tauri::WindowUrl::External(url.parse()?))
@@ -170,7 +170,7 @@ pub async fn initialise_plugin(path: &path::PathBuf) -> anyhow::Result<()> {
 		))?;
 
 		INSTANCES.lock().await.insert(plugin_uuid.to_owned(), PluginInstance::Webview);
-	} else if code_path.ends_with(".js") {
+	} else if code_path.ends_with(".js") || code_path.ends_with(".mjs") || code_path.ends_with(".cjs") {
 		if Command::new("node").stdout(Stdio::null()).stderr(Stdio::null()).spawn().is_err() {
 			return Err(anyhow!("failed to detect an installation of Node"));
 		}

--- a/src-tauri/src/plugins/mod.rs
+++ b/src-tauri/src/plugins/mod.rs
@@ -25,6 +25,7 @@ enum PluginInstance {
 	Webview,
 	Wine(Child),
 	Native(Child),
+	Node(Child),
 }
 
 static INSTANCES: Lazy<Mutex<HashMap<String, PluginInstance>>> = Lazy::new(|| Mutex::new(HashMap::new()));
@@ -169,6 +170,36 @@ pub async fn initialise_plugin(path: &path::PathBuf) -> anyhow::Result<()> {
 		))?;
 
 		INSTANCES.lock().await.insert(plugin_uuid.to_owned(), PluginInstance::Webview);
+	} else if code_path.ends_with(".js") {
+		if Command::new("node").stdout(Stdio::null()).stderr(Stdio::null()).spawn().is_err() {
+			return Err(anyhow!("failed to detect an installation of Node"));
+		}
+		if Command::new("node").arg("--version").output().unwrap().stdout.as_slice() < "v20.0.0".as_bytes() {
+			return Err(anyhow!("Node version 20.0.0 or higher is required"));
+		}
+
+		let info = info_param::make_info(plugin_uuid.to_owned(), manifest.version, true).await;
+		let log_file = fs::File::create(path.parent().unwrap().parent().unwrap().join("logs").join("plugins").join(format!("{plugin_uuid}.log")))?;
+		// Start Node with the appropriate arguments.
+		let child = Command::new("node")
+				.current_dir(path)
+				.args([
+						code_path,
+						String::from("-port"),
+						57116.to_string(),
+						String::from("-pluginUUID"),
+						plugin_uuid.to_owned(),
+						String::from("-registerEvent"),
+						String::from("registerPlugin"),
+						String::from("-info"),
+						serde_json::to_string(&info)?,
+				])
+				.stdout(Stdio::from(log_file.try_clone()?))
+				.stderr(Stdio::from(log_file))
+				.spawn()?;
+
+
+		INSTANCES.lock().await.insert(plugin_uuid.to_owned(), PluginInstance::Node(child));
 	} else if use_wine {
 		if Command::new("wine").stdout(Stdio::null()).stderr(Stdio::null()).spawn().is_err() {
 			return Err(anyhow!("failed to detect an installation of Wine"));
@@ -247,7 +278,7 @@ pub async fn deactivate_plugin(app: &AppHandle, uuid: &str) -> Result<(), anyhow
 				let window = app.get_window(&uuid.replace('.', "_")).unwrap();
 				Ok(window.close()?)
 			}
-			PluginInstance::Wine(child) | PluginInstance::Native(child) => Ok(child.kill()?),
+			PluginInstance::Node(child) |PluginInstance::Wine(child) | PluginInstance::Native(child) => Ok(child.kill()?),
 		}
 	} else {
 		Err(anyhow!("instance of plugin {} not found", uuid))

--- a/src-tauri/src/plugins/mod.rs
+++ b/src-tauri/src/plugins/mod.rs
@@ -171,11 +171,10 @@ pub async fn initialise_plugin(path: &path::PathBuf) -> anyhow::Result<()> {
 
 		INSTANCES.lock().await.insert(plugin_uuid.to_owned(), PluginInstance::Webview);
 	} else if code_path.ends_with(".js") || code_path.ends_with(".mjs") || code_path.ends_with(".cjs") {
-		if Command::new("node").stdout(Stdio::null()).stderr(Stdio::null()).spawn().is_err() {
-			return Err(anyhow!("failed to detect an installation of Node"));
-		}
-		if Command::new("node").arg("--version").output().unwrap().stdout.as_slice() < "v20.0.0".as_bytes() {
-			return Err(anyhow!("Node version 20.0.0 or higher is required"));
+		// Check for Node.js installation and version in one go.
+		let version_output = Command::new("node").arg("--version").output();
+		if version_output.is_err() || String::from_utf8(version_output.unwrap().stdout).unwrap().trim() < "v20.0.0" {
+			return Err(anyhow!("Node version 20.0.0 or higher is required, or Node is not installed"));
 		}
 
 		let info = info_param::make_info(plugin_uuid.to_owned(), manifest.version, true).await;

--- a/src-tauri/src/plugins/mod.rs
+++ b/src-tauri/src/plugins/mod.rs
@@ -140,9 +140,9 @@ pub async fn initialise_plugin(path: &path::PathBuf) -> anyhow::Result<()> {
 		devices.push(device.into());
 	}
 
-	let code_path = code_path.unwrap().to_lowercase();
+	let code_path = code_path.unwrap();
 
-	if code_path.ends_with(".html") || code_path.ends_with(".htm") || code_path.ends_with(".xhtml") {
+	if code_path.to_lowercase().ends_with(".html") || code_path.to_lowercase().ends_with(".htm") || code_path.to_lowercase().ends_with(".xhtml") {
 		// Create a webview window for the plugin and call its registration function.
 		let url = "http://localhost:57118/".to_owned() + path.join(code_path).to_str().unwrap();
 		let window = tauri::WindowBuilder::new(APP_HANDLE.get().unwrap(), plugin_uuid.replace('.', "_"), tauri::WindowUrl::External(url.parse()?))
@@ -170,7 +170,7 @@ pub async fn initialise_plugin(path: &path::PathBuf) -> anyhow::Result<()> {
 		))?;
 
 		INSTANCES.lock().await.insert(plugin_uuid.to_owned(), PluginInstance::Webview);
-	} else if code_path.ends_with(".js") || code_path.ends_with(".mjs") || code_path.ends_with(".cjs") {
+	} else if code_path.to_lowercase().ends_with(".js") || code_path.to_lowercase().ends_with(".mjs") || code_path.to_lowercase().ends_with(".cjs") {
 		// Check for Node.js installation and version in one go.
 		let version_output = Command::new("node").arg("--version").output();
 		if version_output.is_err() || String::from_utf8(version_output.unwrap().stdout).unwrap().trim() < "v20.0.0" {

--- a/src-tauri/src/plugins/mod.rs
+++ b/src-tauri/src/plugins/mod.rs
@@ -182,22 +182,21 @@ pub async fn initialise_plugin(path: &path::PathBuf) -> anyhow::Result<()> {
 		let log_file = fs::File::create(path.parent().unwrap().parent().unwrap().join("logs").join("plugins").join(format!("{plugin_uuid}.log")))?;
 		// Start Node with the appropriate arguments.
 		let child = Command::new("node")
-				.current_dir(path)
-				.args([
-						code_path,
-						String::from("-port"),
-						57116.to_string(),
-						String::from("-pluginUUID"),
-						plugin_uuid.to_owned(),
-						String::from("-registerEvent"),
-						String::from("registerPlugin"),
-						String::from("-info"),
-						serde_json::to_string(&info)?,
-				])
-				.stdout(Stdio::from(log_file.try_clone()?))
-				.stderr(Stdio::from(log_file))
-				.spawn()?;
-
+			.current_dir(path)
+			.args([
+				code_path,
+				String::from("-port"),
+				57116.to_string(),
+				String::from("-pluginUUID"),
+				plugin_uuid.to_owned(),
+				String::from("-registerEvent"),
+				String::from("registerPlugin"),
+				String::from("-info"),
+				serde_json::to_string(&info)?,
+			])
+			.stdout(Stdio::from(log_file.try_clone()?))
+			.stderr(Stdio::from(log_file))
+			.spawn()?;
 
 		INSTANCES.lock().await.insert(plugin_uuid.to_owned(), PluginInstance::Node(child));
 	} else if use_wine {
@@ -278,7 +277,7 @@ pub async fn deactivate_plugin(app: &AppHandle, uuid: &str) -> Result<(), anyhow
 				let window = app.get_window(&uuid.replace('.', "_")).unwrap();
 				Ok(window.close()?)
 			}
-			PluginInstance::Node(child) |PluginInstance::Wine(child) | PluginInstance::Native(child) => Ok(child.kill()?),
+			PluginInstance::Node(child) | PluginInstance::Wine(child) | PluginInstance::Native(child) => Ok(child.kill()?),
 		}
 	} else {
 		Err(anyhow!("instance of plugin {} not found", uuid))


### PR DESCRIPTION
# Description

- Add the ability to load NodeJS plugin.

# How to test ?

⚠️ It is required to have node (minimum version 20 installed, plugin shoudn't work without the proper version anyway and opendeck will return an error) 

Install elgato's npm cli & create a basic nodeJS plugin
- `npm install -g @elgato/cli`
- `streamdeck create`
- fill the prompts
- build with plugin

checkout [elgato's readme](https://github.com/elgatosf/streamdeck) for more info about nodejs plugins.


Rest is rocket science.